### PR TITLE
Add support for extracting block and character devices, and minor cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ JFFS2 filesystem extraction tool
 
 Installation
 ============
-
 ```bash
 $ sudo python setup.py install
 ```
@@ -11,8 +10,7 @@ $ sudo python setup.py install
 
 Dependencies
 ============
-
-- `cstuct`
+- `cstruct`
 - `pyliblzma`
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ sudo apt-get install python-lzma
 Features
 ============
 - Big/Little Endian support
-- `JFFS2_COMPR_ZLIB`, `JFFS2_COMPR_RTIME`, `JFFS2_COMPR_LZMA` and `JFFS2_COMPR_NONE` compression support
+- `JFFS2_COMPR_ZLIB`, `JFFS2_COMPR_RTIME`, and `JFFS2_COMPR_LZMA` compression support
 - CRC checks - for now only enforced on `hdr_crc`
 - Extraction of symlinks, directories, files, and device nodes
 - Detection/handling of duplicate inode numbers. Occurs if multiple JFFS2 filesystems are found in one file and causes `jefferson` to treat segments as separate filesystems

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Features
 - Big/Little Endian support
 - `JFFS2_COMPR_ZLIB`, `JFFS2_COMPR_RTIME`, `JFFS2_COMPR_LZMA` and `JFFS2_COMPR_NONE` compression support
 - CRC checks - for now only enforced on `hdr_crc`
-- Extraction of symlinks, directories and files
+- Extraction of symlinks, directories, files, and device nodes
 - Detection/handling of duplicate inode numbers. Occurs if multiple JFFS2 filesystems are found in one file and causes `jefferson` to treat segments as separate filesystems
 
 Usage

--- a/src/scripts/jefferson
+++ b/src/scripts/jefferson
@@ -228,6 +228,17 @@ class Jffs2_raw_inode(cstruct.CStruct):
             print 'data_crc does not match!'
             self.data_crc_match = False
 
+class Jffs2_device_node_old(cstruct.CStruct):
+    __byte_order__ = cstruct.LITTLE_ENDIAN
+    __struct__ = """
+        jint16_t old_id;
+    """
+
+class Jffs2_device_node_new(cstruct.CStruct):
+    __byte_order__ = cstruct.LITTLE_ENDIAN
+    __struct__ = """
+        jint32_t new_id;
+    """
 
 NODETYPES = {
     JFFS2_FEATURE_INCOMPAT: Jffs2_unknown_node,
@@ -242,6 +253,9 @@ NODETYPES = {
 
 
 def set_endianness(endianness):
+    Jffs2_device_node_new.__fmt__ = endianness + Jffs2_device_node_new.__fmt__[1:]
+    Jffs2_device_node_old.__fmt__ = endianness + Jffs2_device_node_old.__fmt__[1:]
+
     for node in NODETYPES.values():
         if isinstance(node, cstruct.CStructMeta):
             node.__fmt__ = endianness + node.__fmt__[1:]
@@ -256,6 +270,7 @@ def scan_fs(content, endianness, verbose=False):
 
     fs = {}
     fs[fs_index] = {}
+    fs[fs_index]["endianness"] = endianness
     fs[fs_index][JFFS2_NODETYPE_INODE] = []
     fs[fs_index][JFFS2_NODETYPE_DIRENT] = []
     fs[fs_index][JFFS2_NODETYPE_XATTR] = []
@@ -333,8 +348,25 @@ def scan_fs(content, endianness, verbose=False):
     return fs.values()
 
 
+def get_device(inode):
+    if not stat.S_ISBLK(inode.mode) and not stat.S_ISCHR(inode.mode):
+        return None
+
+    if inode.dsize == len(Jffs2_device_node_new):
+        node = Jffs2_device_node_new()
+        node.unpack(inode.data)
+        return os.makedev((node.new_id & 0xfff00) >> 8, (node.new_id & 0xff) | ((node.new_id >> 12) & 0xfff00))
+    elif inode.dsize == len(Jffs2_device_node_old):
+        node = Jffs2_device_node_old()
+        node.unpack(inode.data)
+        return os.makedev((node.old_id >> 8) & 0xff, node.old_id & 0xff)
+    return None
+
+
 def dump_fs(fs, target):
     node_dict = {}
+
+    set_endianness(fs["endianness"])
 
     for dirent in fs[JFFS2_NODETYPE_DIRENT]:
         dirent.inodes = []
@@ -389,9 +421,11 @@ def dump_fs(fs, target):
                     os.chmod(target_path, stat.S_IMODE(inode.mode))
                     break
                 elif stat.S_ISCHR(inode.mode):
-                    print 'skipping S_ISCHR', path
+                    print 'writing S_ISBLK', path
+                    os.mknod(target_path, inode.mode, get_device(inode))
                 elif stat.S_ISBLK(inode.mode):
-                    print 'skipping S_ISBLK', path
+                    print 'writing S_ISBLK', path
+                    os.mknod(target_path, inode.mode, get_device(inode))
                 elif stat.S_ISFIFO(inode.mode):
                     print 'skipping S_ISFIFO', path
                 elif stat.S_ISSOCK(inode.mode):
@@ -437,8 +471,15 @@ def main():
 
         dest_path_fs = os.path.join(dest_path, 'fs_%i' % fs_index)
         print 'dumping fs #%i to %s' % (fs_index, dest_path_fs)
-        for type, nodes in fs.iteritems():
-            print '%s count: %i' % (NODETYPES[type].__name__, len(nodes))
+        for key, value in fs.iteritems():
+            if key == "endianness":
+                if value == cstruct.BIG_ENDIAN:
+                    print 'Endianness: Big'
+                elif value == cstruct.LITTLE_ENDIAN:
+                    print 'Endianness: Small'
+                continue
+
+            print '%s count: %i' % (NODETYPES[key].__name__, len(value))
 
         if not os.path.exists(dest_path_fs):
             os.mkdir(dest_path_fs)

--- a/src/scripts/jefferson
+++ b/src/scripts/jefferson
@@ -202,6 +202,8 @@ class Jffs2_raw_inode(cstruct.CStruct):
         node_data = data[self.size:self.size + self.csize]
         if self.compr == JFFS2_COMPR_NONE:
             self.data = node_data
+        elif self.compr == JFFS2_COMPR_ZERO:
+            self.data = '\x00' * self.dsize
         elif self.compr == JFFS2_COMPR_ZLIB:
             self.data = zlib.decompress(node_data)
         elif self.compr == JFFS2_COMPR_RTIME:

--- a/src/scripts/jefferson
+++ b/src/scripts/jefferson
@@ -60,11 +60,11 @@ cstruct.typedef('uint32', 'jmode_t')
 class Jffs2_unknown_node(cstruct.CStruct):
     __byte_order__ = cstruct.LITTLE_ENDIAN
     __struct__ = """
-	/* All start like this */
-	jint16_t magic;
-	jint16_t nodetype;
-	jint32_t totlen; /* So we can skip over nodes we don't grok */
-	jint32_t hdr_crc;
+        /* All start like this */
+        jint16_t magic;
+        jint16_t nodetype;
+        jint32_t totlen; /* So we can skip over nodes we don't grok */
+        jint32_t hdr_crc;
     """
 
     def unpack(self, data):
@@ -81,67 +81,67 @@ class Jffs2_unknown_node(cstruct.CStruct):
 class Jffs2_raw_xattr(cstruct.CStruct):
     __byte_order__ = cstruct.LITTLE_ENDIAN
     __struct__ = """
-	jint16_t magic;
-	jint16_t nodetype;	/* = JFFS2_NODETYPE_XATTR */
-	jint32_t totlen;
-	jint32_t hdr_crc;
-	jint32_t xid;		/* XATTR identifier number */
-	jint32_t version;
-	uint8_t xprefix;
-	uint8_t name_len;
-	jint16_t value_len;
-	jint32_t data_crc;
-	jint32_t node_crc;
-	uint8_t data[0];
+        jint16_t magic;
+        jint16_t nodetype;      /* = JFFS2_NODETYPE_XATTR */
+        jint32_t totlen;
+        jint32_t hdr_crc;
+        jint32_t xid;           /* XATTR identifier number */
+        jint32_t version;
+        uint8_t xprefix;
+        uint8_t name_len;
+        jint16_t value_len;
+        jint32_t data_crc;
+        jint32_t node_crc;
+        uint8_t data[0];
     """
 
 
 class Jffs2_raw_summary(cstruct.CStruct):
     __byte_order__ = cstruct.LITTLE_ENDIAN
     __struct__ = """
-	jint16_t magic;
-	jint16_t nodetype; 	/* = JFFS2_NODETYPE_SUMMARY */
-	jint32_t totlen;
-	jint32_t hdr_crc;
-	jint32_t sum_num;	/* number of sum entries*/
-	jint32_t cln_mkr;	/* clean marker size, 0 = no cleanmarker */
-	jint32_t padded;	/* sum of the size of padding nodes */
-	jint32_t sum_crc;	/* summary information crc */
-	jint32_t node_crc; 	/* node crc */
-	jint32_t sum[0]; 	/* inode summary info */
+        jint16_t magic;
+        jint16_t nodetype;      /* = JFFS2_NODETYPE_SUMMARY */
+        jint32_t totlen;
+        jint32_t hdr_crc;
+        jint32_t sum_num;       /* number of sum entries*/
+        jint32_t cln_mkr;       /* clean marker size, 0 = no cleanmarker */
+        jint32_t padded;        /* sum of the size of padding nodes */
+        jint32_t sum_crc;       /* summary information crc */
+        jint32_t node_crc;      /* node crc */
+        jint32_t sum[0];        /* inode summary info */
     """
 
 
 class Jffs2_raw_xref(cstruct.CStruct):
     __byte_order__ = cstruct.LITTLE_ENDIAN
     __struct__ = """
-	jint16_t magic;
-	jint16_t nodetype;	/* = JFFS2_NODETYPE_XREF */
-	jint32_t totlen;
-	jint32_t hdr_crc;
-	jint32_t ino;		/* inode number */
-	jint32_t xid;		/* XATTR identifier number */
-	jint32_t xseqno;	/* xref sequencial number */
-	jint32_t node_crc;
+        jint16_t magic;
+        jint16_t nodetype;      /* = JFFS2_NODETYPE_XREF */
+        jint32_t totlen;
+        jint32_t hdr_crc;
+        jint32_t ino;           /* inode number */
+        jint32_t xid;           /* XATTR identifier number */
+        jint32_t xseqno;        /* xref sequencial number */
+        jint32_t node_crc;
     """
 
 
 class Jffs2_raw_dirent(cstruct.CStruct):
     __byte_order__ = cstruct.LITTLE_ENDIAN
     __struct__ = """
-	jint16_t magic;
-	jint16_t nodetype;	/* == JFFS2_NODETYPE_DIRENT */
-	jint32_t totlen;
-	jint32_t hdr_crc;
-	jint32_t pino;
-	jint32_t version;
-	jint32_t ino; /* == zero for unlink */
-	jint32_t mctime;
-	uint8_t nsize;
-	uint8_t type;
-	uint8_t unused[2];
-	jint32_t node_crc;
-	jint32_t name_crc;
+        jint16_t magic;
+        jint16_t nodetype;      /* == JFFS2_NODETYPE_DIRENT */
+        jint32_t totlen;
+        jint32_t hdr_crc;
+        jint32_t pino;
+        jint32_t version;
+        jint32_t ino; /* == zero for unlink */
+        jint32_t mctime;
+        uint8_t nsize;
+        uint8_t type;
+        uint8_t unused[2];
+        jint32_t node_crc;
+        jint32_t name_crc;
     /* uint8_t data[0]; -> name */
     """
 
@@ -172,28 +172,28 @@ class Jffs2_raw_dirent(cstruct.CStruct):
 class Jffs2_raw_inode(cstruct.CStruct):
     __byte_order__ = cstruct.LITTLE_ENDIAN
     __struct__ = """
-	jint16_t magic;      /* A constant magic number.  */
-	jint16_t nodetype;   /* == JFFS2_NODETYPE_INODE */
-	jint32_t totlen;     /* Total length of this node (inc data, etc.) */
-	jint32_t hdr_crc;
-	jint32_t ino;        /* Inode number.  */
-	jint32_t version;    /* Version number.  */
-	jmode_t mode;       /* The file's type or mode.  */
-	jint16_t uid;        /* The file's owner.  */
-	jint16_t gid;        /* The file's group.  */
-	jint32_t isize;      /* Total resultant size of this inode (used for truncations)  */
-	jint32_t atime;      /* Last access time.  */
-	jint32_t mtime;      /* Last modification time.  */
-	jint32_t ctime;      /* Change time.  */
-	jint32_t offset;     /* Where to begin to write.  */
-	jint32_t csize;      /* (Compressed) data size */
-	jint32_t dsize;	     /* Size of the node's data. (after decompression) */
-	uint8_t compr;       /* Compression algorithm used */
-	uint8_t usercompr;   /* Compression algorithm requested by the user */
-	jint16_t flags;	     /* See JFFS2_INO_FLAG_* */
-	jint32_t data_crc;   /* CRC for the (compressed) data.  */
-	jint32_t node_crc;   /* CRC for the raw inode (excluding data)  */
-	/* uint8_t data[0]; */
+        jint16_t magic;      /* A constant magic number.  */
+        jint16_t nodetype;   /* == JFFS2_NODETYPE_INODE */
+        jint32_t totlen;     /* Total length of this node (inc data, etc.) */
+        jint32_t hdr_crc;
+        jint32_t ino;        /* Inode number.  */
+        jint32_t version;    /* Version number.  */
+        jmode_t mode;       /* The file's type or mode.  */
+        jint16_t uid;        /* The file's owner.  */
+        jint16_t gid;        /* The file's group.  */
+        jint32_t isize;      /* Total resultant size of this inode (used for truncations)  */
+        jint32_t atime;      /* Last access time.  */
+        jint32_t mtime;      /* Last modification time.  */
+        jint32_t ctime;      /* Change time.  */
+        jint32_t offset;     /* Where to begin to write.  */
+        jint32_t csize;      /* (Compressed) data size */
+        jint32_t dsize;      /* Size of the node's data. (after decompression) */
+        uint8_t compr;       /* Compression algorithm used */
+        uint8_t usercompr;   /* Compression algorithm requested by the user */
+        jint16_t flags;      /* See JFFS2_INO_FLAG_* */
+        jint32_t data_crc;   /* CRC for the (compressed) data.  */
+        jint32_t node_crc;   /* CRC for the raw inode (excluding data)  */
+        /* uint8_t data[0]; */
     """
 
     def unpack(self, data):


### PR DESCRIPTION
Not sure if the tuple is the best way to store the endianness for each inode, but it seemed easiest.
