### PR TITLE
Switched to lzma in python stdlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ $ sudo python3 setup.py install
 Dependencies
 ============
 - `cstruct`
-- `pylzma`
 
 ```bash
 $ sudo pip3 install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 cstruct
-pylzma

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author="Stefan Viehböck",
     url="https://github.com/sviehb/jefferson",
     license="MIT",
-    requires=['cstruct', 'pylzma'],
+    requires=['cstruct'],
     packages=["jefferson"],
     package_dir={"jefferson": "src/jefferson"},
     scripts=["src/scripts/jefferson"],

--- a/src/jefferson/jffs2_lzma.py
+++ b/src/jefferson/jffs2_lzma.py
@@ -1,6 +1,6 @@
 import struct
 
-import pylzma
+import lzma
 
 LZMA_BEST_LC = 0
 LZMA_BEST_LP = 0
@@ -17,5 +17,5 @@ DICT_SIZE = 0x2000
 def decompress(data, outlen):
     lzma_header = struct.pack("<BIQ", PROPERTIES, DICT_SIZE, outlen)
     lzma_data = lzma_header + data
-    decompressed = pylzma.decompress(lzma_data)
+    decompressed = lzma.decompress(lzma_data)
     return decompressed


### PR DESCRIPTION
No reason to use a pip package now that python's standard library includes lzma