### PR TITLE
Significant speedup for large filesystems and minimizing physical memory usage

### DIFF
--- a/src/scripts/jefferson
+++ b/src/scripts/jefferson
@@ -151,6 +151,8 @@ class Jffs2_raw_dirent(cstruct.CStruct):
     def unpack(self, data, node_offset):
         cstruct.CStruct.unpack(self, data[: self.size])
         self.name = data[self.size : self.size + self.nsize]
+        if isinstance(self.name, memoryview):
+            self.name = self.name.tobytes()
         self.node_offset = node_offset
 
         if mtd_crc(data[: self.size - 8]) == self.node_crc:
@@ -203,6 +205,8 @@ class Jffs2_raw_inode(cstruct.CStruct):
         cstruct.CStruct.unpack(self, data[: self.size])
 
         node_data = data[self.size : self.size + self.csize]
+        if isinstance(node_data, memoryview):
+            node_data = node_data.tobytes()
         if self.compr == JFFS2_COMPR_NONE:
             self.data = node_data
         elif self.compr == JFFS2_COMPR_ZERO:
@@ -275,6 +279,7 @@ def scan_fs(content, endianness, verbose=False):
     pos = 0
     jffs2_magic_bitmask_str = struct.pack(endianness + "H", JFFS2_MAGIC_BITMASK)
     fs_index = 0
+    content_mv = memoryview(content)
 
     fs = {}
     fs[fs_index] = {}
@@ -296,7 +301,7 @@ def scan_fs(content, endianness, verbose=False):
             pos = find_result
 
         unknown_node = Jffs2_unknown_node()
-        unknown_node.unpack(content[pos : pos + unknown_node.size])
+        unknown_node.unpack(content_mv[pos : pos + unknown_node.size])
         if not unknown_node.hdr_crc_match:
             pos += 1
             continue
@@ -307,7 +312,7 @@ def scan_fs(content, endianness, verbose=False):
             if unknown_node.nodetype in NODETYPES:
                 if unknown_node.nodetype == JFFS2_NODETYPE_DIRENT:
                     dirent = Jffs2_raw_dirent()
-                    dirent.unpack(content[0 + offset :], offset)
+                    dirent.unpack(content_mv[0 + offset :], offset)
                     if dirent.ino in dirent_dict:
                         print("duplicate inode use detected!!!")
                         fs_index += 1
@@ -327,25 +332,25 @@ def scan_fs(content, endianness, verbose=False):
                         print("0x%08X:" % (offset), dirent)
                 elif unknown_node.nodetype == JFFS2_NODETYPE_INODE:
                     inode = Jffs2_raw_inode()
-                    inode.unpack(content[0 + offset :])
+                    inode.unpack(content_mv[0 + offset :])
                     fs[fs_index][JFFS2_NODETYPE_INODE].append(inode)
                     if verbose:
                         print("0x%08X:" % (offset), inode)
                 elif unknown_node.nodetype == JFFS2_NODETYPE_XREF:
                     xref = Jffs2_raw_xref()
-                    xref.unpack(content[offset : offset + xref.size])
+                    xref.unpack(content_mv[offset : offset + xref.size])
                     fs[fs_index][JFFS2_NODETYPE_XREF].append(xref)
                     if verbose:
                         print("0x%08X:" % (offset), xref)
                 elif unknown_node.nodetype == JFFS2_NODETYPE_XATTR:
                     xattr = Jffs2_raw_xattr()
-                    xattr.unpack(content[offset : offset + xattr.size])
+                    xattr.unpack(content_mv[offset : offset + xattr.size])
                     fs[fs_index][JFFS2_NODETYPE_XREF].append(xattr)
                     if verbose:
                         print("0x%08X:" % (offset), xattr)
                 elif unknown_node.nodetype == JFFS2_NODETYPE_SUMMARY:
                     summary = Jffs2_raw_summary()
-                    summary.unpack(content[offset : offset + summary.size])
+                    summary.unpack(content_mv[offset : offset + summary.size])
                     summaries.append(summary)
                     fs[fs_index][JFFS2_NODETYPE_SUMMARY].append(summary)
                     if verbose:

--- a/src/scripts/jefferson
+++ b/src/scripts/jefferson
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import argparse
+import contextlib
+import mmap
 import struct
 import stat
 import os
@@ -478,11 +480,16 @@ def main():
     else:
         os.mkdir(dest_path)
 
-    with open(args.filesystem, "rb") as filesystem:
-        content = filesystem.read()
+    with contextlib.ExitStack() as context_stack:
+        filesystem = context_stack.enter_context(open(args.filesystem, "rb"))
+        filesystem_len = os.fstat(filesystem.fileno()).st_size
+        if 0 == filesystem_len:  # Cannot create a 0-byte mapping
+            return
+        content = context_stack.enter_context(mmap.mmap(filesystem.fileno(), filesystem_len,
+                                                        access=mmap.ACCESS_READ))
 
-    fs_list = list(scan_fs(content, cstruct.BIG_ENDIAN, verbose=args.verbose))
-    fs_list += list(scan_fs(content, cstruct.LITTLE_ENDIAN, verbose=args.verbose))
+        fs_list = list(scan_fs(content, cstruct.BIG_ENDIAN, verbose=args.verbose))
+        fs_list += list(scan_fs(content, cstruct.LITTLE_ENDIAN, verbose=args.verbose))
 
     fs_index = 1
     for fs in fs_list:


### PR DESCRIPTION
For large filesystems (100MB+) `jefferson` runs very slowly, because every time a JFFS2 header is found, the `unpack()` method is given a slice of data using syntax like `content[0 + offset :]`.  When the filesystem is very large, this causes Python under the hood to `mmap` enough physical memory to hold that data slice, to copy the original data into that physical memory mapping, and then to perform userspace processing before calling `munmap`.  Most of the runtime is spent copying data and then discarding that data.

However, by using Python's `memoryview` class, we can avoid all of the `mmap` calls and copying of data.  This significantly improves the speed of processing large filesystems.  There are minimal code changes required to utilize `memoryview`.

Additionally, instead of reading the entire filesystem into physical memory, an `mmap` is used to map the file into virtual address space.  This allows the kernel to choose the best way to manage memory, whether that's loading the entire file into physical memory or just loading 1 or more pages of the file into physical memory at a time.  In any case, this minimizes the amount of physical memory used.