### PR TITLE
update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-cstruct
+cstruct==1.8


### PR DESCRIPTION
cstruct v2 removes the `__fmt__` attribute which breaks how jefferson handles endianness.
recommend pinning to `v1.8` until the code can be revised to support cstruct v2.

fixes #33