### PR TITLE
Generic improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ sudo pip3 install -r requirements.txt
 Features
 ============
 - Big/Little Endian support
-- `JFFS2_COMPR_ZLIB`, `JFFS2_COMPR_RTIME`, and `JFFS2_COMPR_LZMA` compression support
+- zlib, rtime, LZMA, and LZO compression support
 - CRC checks - for now only enforced on `hdr_crc`
 - Extraction of symlinks, directories, files, and device nodes
 - Detection/handling of duplicate inode numbers. Occurs if multiple JFFS2 filesystems are found in one file and causes `jefferson` to treat segments as separate filesystems

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 cstruct==2.1
+python-lzo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-cstruct
+cstruct==2.1

--- a/src/scripts/jefferson
+++ b/src/scripts/jefferson
@@ -60,12 +60,14 @@ cstruct.typedef("uint32", "jmode_t")
 
 class Jffs2_unknown_node(cstruct.CStruct):
     __byte_order__ = cstruct.LITTLE_ENDIAN
-    __struct__ = """
-        /* All start like this */
-        jint16_t magic;
-        jint16_t nodetype;
-        jint32_t totlen; /* So we can skip over nodes we don't grok */
-        jint32_t hdr_crc;
+    __def__ = """
+        struct {
+            /* All start like this */
+            jint16_t magic;
+            jint16_t nodetype;
+            jint32_t totlen; /* So we can skip over nodes we don't grok */
+            jint32_t hdr_crc;
+        }
     """
 
     def unpack(self, data):
@@ -81,69 +83,77 @@ class Jffs2_unknown_node(cstruct.CStruct):
 
 class Jffs2_raw_xattr(cstruct.CStruct):
     __byte_order__ = cstruct.LITTLE_ENDIAN
-    __struct__ = """
-        jint16_t magic;
-        jint16_t nodetype;      /* = JFFS2_NODETYPE_XATTR */
-        jint32_t totlen;
-        jint32_t hdr_crc;
-        jint32_t xid;           /* XATTR identifier number */
-        jint32_t version;
-        uint8_t xprefix;
-        uint8_t name_len;
-        jint16_t value_len;
-        jint32_t data_crc;
-        jint32_t node_crc;
-        uint8_t data[0];
+    __def__ = """
+        struct {
+            jint16_t magic;
+            jint16_t nodetype;      /* = JFFS2_NODETYPE_XATTR */
+            jint32_t totlen;
+            jint32_t hdr_crc;
+            jint32_t xid;           /* XATTR identifier number */
+            jint32_t version;
+            uint8_t xprefix;
+            uint8_t name_len;
+            jint16_t value_len;
+            jint32_t data_crc;
+            jint32_t node_crc;
+            uint8_t data[0];
+        }
     """
 
 
 class Jffs2_raw_summary(cstruct.CStruct):
     __byte_order__ = cstruct.LITTLE_ENDIAN
-    __struct__ = """
-        jint16_t magic;
-        jint16_t nodetype;      /* = JFFS2_NODETYPE_SUMMARY */
-        jint32_t totlen;
-        jint32_t hdr_crc;
-        jint32_t sum_num;       /* number of sum entries*/
-        jint32_t cln_mkr;       /* clean marker size, 0 = no cleanmarker */
-        jint32_t padded;        /* sum of the size of padding nodes */
-        jint32_t sum_crc;       /* summary information crc */
-        jint32_t node_crc;      /* node crc */
-        jint32_t sum[0];        /* inode summary info */
+    __def__ = """
+        struct {
+            jint16_t magic;
+            jint16_t nodetype;      /* = JFFS2_NODETYPE_SUMMARY */
+            jint32_t totlen;
+            jint32_t hdr_crc;
+            jint32_t sum_num;       /* number of sum entries*/
+            jint32_t cln_mkr;       /* clean marker size, 0 = no cleanmarker */
+            jint32_t padded;        /* sum of the size of padding nodes */
+            jint32_t sum_crc;       /* summary information crc */
+            jint32_t node_crc;      /* node crc */
+            jint32_t sum[0];        /* inode summary info */
+        }
     """
 
 
 class Jffs2_raw_xref(cstruct.CStruct):
     __byte_order__ = cstruct.LITTLE_ENDIAN
-    __struct__ = """
-        jint16_t magic;
-        jint16_t nodetype;      /* = JFFS2_NODETYPE_XREF */
-        jint32_t totlen;
-        jint32_t hdr_crc;
-        jint32_t ino;           /* inode number */
-        jint32_t xid;           /* XATTR identifier number */
-        jint32_t xseqno;        /* xref sequencial number */
-        jint32_t node_crc;
+    __def__ = """
+        struct {
+            jint16_t magic;
+            jint16_t nodetype;      /* = JFFS2_NODETYPE_XREF */
+            jint32_t totlen;
+            jint32_t hdr_crc;
+            jint32_t ino;           /* inode number */
+            jint32_t xid;           /* XATTR identifier number */
+            jint32_t xseqno;        /* xref sequencial number */
+            jint32_t node_crc;
+        }
     """
 
 
 class Jffs2_raw_dirent(cstruct.CStruct):
     __byte_order__ = cstruct.LITTLE_ENDIAN
-    __struct__ = """
-        jint16_t magic;
-        jint16_t nodetype;      /* == JFFS2_NODETYPE_DIRENT */
-        jint32_t totlen;
-        jint32_t hdr_crc;
-        jint32_t pino;
-        jint32_t version;
-        jint32_t ino; /* == zero for unlink */
-        jint32_t mctime;
-        uint8_t nsize;
-        uint8_t type;
-        uint8_t unused[2];
-        jint32_t node_crc;
-        jint32_t name_crc;
-    /* uint8_t data[0]; -> name */
+    __def__ = """
+        struct {
+            jint16_t magic;
+            jint16_t nodetype;      /* == JFFS2_NODETYPE_DIRENT */
+            jint32_t totlen;
+            jint32_t hdr_crc;
+            jint32_t pino;
+            jint32_t version;
+            jint32_t ino; /* == zero for unlink */
+            jint32_t mctime;
+            uint8_t nsize;
+            uint8_t type;
+            uint8_t unused[2];
+            jint32_t node_crc;
+            jint32_t name_crc;
+        /* uint8_t data[0]; -> name */
+        }
     """
 
     def unpack(self, data, node_offset):
@@ -172,29 +182,31 @@ class Jffs2_raw_dirent(cstruct.CStruct):
 
 class Jffs2_raw_inode(cstruct.CStruct):
     __byte_order__ = cstruct.LITTLE_ENDIAN
-    __struct__ = """
-        jint16_t magic;      /* A constant magic number.  */
-        jint16_t nodetype;   /* == JFFS2_NODETYPE_INODE */
-        jint32_t totlen;     /* Total length of this node (inc data, etc.) */
-        jint32_t hdr_crc;
-        jint32_t ino;        /* Inode number.  */
-        jint32_t version;    /* Version number.  */
-        jmode_t mode;       /* The file's type or mode.  */
-        jint16_t uid;        /* The file's owner.  */
-        jint16_t gid;        /* The file's group.  */
-        jint32_t isize;      /* Total resultant size of this inode (used for truncations)  */
-        jint32_t atime;      /* Last access time.  */
-        jint32_t mtime;      /* Last modification time.  */
-        jint32_t ctime;      /* Change time.  */
-        jint32_t offset;     /* Where to begin to write.  */
-        jint32_t csize;      /* (Compressed) data size */
-        jint32_t dsize;      /* Size of the node's data. (after decompression) */
-        uint8_t compr;       /* Compression algorithm used */
-        uint8_t usercompr;   /* Compression algorithm requested by the user */
-        jint16_t flags;      /* See JFFS2_INO_FLAG_* */
-        jint32_t data_crc;   /* CRC for the (compressed) data.  */
-        jint32_t node_crc;   /* CRC for the raw inode (excluding data)  */
-        /* uint8_t data[0]; */
+    __def__ = """
+        struct {
+            jint16_t magic;      /* A constant magic number.  */
+            jint16_t nodetype;   /* == JFFS2_NODETYPE_INODE */
+            jint32_t totlen;     /* Total length of this node (inc data, etc.) */
+            jint32_t hdr_crc;
+            jint32_t ino;        /* Inode number.  */
+            jint32_t version;    /* Version number.  */
+            jmode_t mode;       /* The file's type or mode.  */
+            jint16_t uid;        /* The file's owner.  */
+            jint16_t gid;        /* The file's group.  */
+            jint32_t isize;      /* Total resultant size of this inode (used for truncations)  */
+            jint32_t atime;      /* Last access time.  */
+            jint32_t mtime;      /* Last modification time.  */
+            jint32_t ctime;      /* Change time.  */
+            jint32_t offset;     /* Where to begin to write.  */
+            jint32_t csize;      /* (Compressed) data size */
+            jint32_t dsize;      /* Size of the node's data. (after decompression) */
+            uint8_t compr;       /* Compression algorithm used */
+            uint8_t usercompr;   /* Compression algorithm requested by the user */
+            jint16_t flags;      /* See JFFS2_INO_FLAG_* */
+            jint32_t data_crc;   /* CRC for the (compressed) data.  */
+            jint32_t node_crc;   /* CRC for the raw inode (excluding data)  */
+            /* uint8_t data[0]; */
+        }
     """
 
     def unpack(self, data):
@@ -204,7 +216,7 @@ class Jffs2_raw_inode(cstruct.CStruct):
         if self.compr == JFFS2_COMPR_NONE:
             self.data = node_data
         elif self.compr == JFFS2_COMPR_ZERO:
-            self.data = b'\x00' * self.dsize
+            self.data = b"\x00" * self.dsize
         elif self.compr == JFFS2_COMPR_ZLIB:
             self.data = zlib.decompress(node_data)
         elif self.compr == JFFS2_COMPR_RTIME:
@@ -234,15 +246,19 @@ class Jffs2_raw_inode(cstruct.CStruct):
 
 class Jffs2_device_node_old(cstruct.CStruct):
     __byte_order__ = cstruct.LITTLE_ENDIAN
-    __struct__ = """
-        jint16_t old_id;
+    __def__ = """
+        struct {
+            jint16_t old_id;
+        }
     """
 
 
 class Jffs2_device_node_new(cstruct.CStruct):
     __byte_order__ = cstruct.LITTLE_ENDIAN
-    __struct__ = """
-        jint32_t new_id;
+    __def__ = """
+        struct {
+            jint32_t new_id;
+        }
     """
 
 
@@ -259,12 +275,55 @@ NODETYPES = {
 
 
 def set_endianness(endianness):
-    Jffs2_device_node_new.__fmt__ = endianness + Jffs2_device_node_new.__fmt__[1:]
-    Jffs2_device_node_old.__fmt__ = endianness + Jffs2_device_node_old.__fmt__[1:]
+    global Jffs2_device_node_new, Jffs2_device_node_old, Jffs2_unknown_node, Jffs2_raw_dirent, Jffs2_raw_inode, Jffs2_raw_summary, Jffs2_raw_xattr, Jffs2_raw_xref
 
-    for node in NODETYPES.values():
-        if isinstance(node, cstruct.CStructMeta):
-            node.__fmt__ = endianness + node.__fmt__[1:]
+    Jffs2_device_node_new = Jffs2_device_node_new.parse(
+        Jffs2_device_node_new.__def__,
+        __name__=Jffs2_device_node_new.__name__,
+        __byte_order__=endianness,
+    )
+
+    Jffs2_device_node_old = Jffs2_device_node_old.parse(
+        Jffs2_device_node_old.__def__,
+        __name__=Jffs2_device_node_old.__name__,
+        __byte_order__=endianness,
+    )
+
+    Jffs2_unknown_node = Jffs2_unknown_node.parse(
+        Jffs2_unknown_node.__def__,
+        __name__=Jffs2_unknown_node.__name__,
+        __byte_order__=endianness,
+    )
+
+    Jffs2_raw_dirent = Jffs2_raw_dirent.parse(
+        Jffs2_raw_dirent.__def__,
+        __name__=Jffs2_raw_dirent.__name__,
+        __byte_order__=endianness,
+    )
+
+    Jffs2_raw_inode = Jffs2_raw_inode.parse(
+        Jffs2_raw_inode.__def__,
+        __name__=Jffs2_raw_inode.__name__,
+        __byte_order__=endianness,
+    )
+
+    Jffs2_raw_summary = Jffs2_raw_summary.parse(
+        Jffs2_raw_summary.__def__,
+        __name__=Jffs2_raw_summary.__name__,
+        __byte_order__=endianness,
+    )
+
+    Jffs2_raw_xattr = Jffs2_raw_xattr.parse(
+        Jffs2_raw_xattr.__def__,
+        __name__=Jffs2_raw_xattr.__name__,
+        __byte_order__=endianness,
+    )
+
+    Jffs2_raw_xref = Jffs2_raw_xref.parse(
+        Jffs2_raw_xref.__def__,
+        __name__=Jffs2_raw_xref.__name__,
+        __byte_order__=endianness,
+    )
 
 
 def scan_fs(content, endianness, verbose=False):

--- a/src/scripts/jefferson
+++ b/src/scripts/jefferson
@@ -6,7 +6,6 @@ import stat
 import os
 import zlib
 import binascii
-
 import cstruct
 
 from jefferson import jffs2_lzma, rtime
@@ -52,6 +51,12 @@ JFFS2_NODETYPE_XREF = JFFS2_FEATURE_INCOMPAT | JFFS2_NODE_ACCURATE | 9
 def mtd_crc(data):
     return (binascii.crc32(data, -1) ^ -1) & 0xFFFFFFFF
 
+def is_safe_path(basedir, path, follow_symlinks=True):
+    if follow_symlinks:
+        matchpath = os.path.realpath(path)
+    else:
+        matchpath = os.path.abspath(path)
+    return basedir == os.path.commonpath((basedir, matchpath))
 
 cstruct.typedef("uint8", "uint8_t")
 cstruct.typedef("uint16", "jint16_t")
@@ -474,7 +479,12 @@ def dump_fs(fs, target):
         node_names.append(dirent.name.decode())
         path = "/".join(node_names)
 
-        target_path = os.path.join(os.getcwd(), target, path)
+        target_path = os.path.realpath(os.path.join(os.getcwd(), target, path))
+
+        if not is_safe_path(target, target_path):
+            print(f"Path traversal attempt to {target_path}, discarding.")
+            continue
+
         for inode in dirent.inodes:
             try:
                 if stat.S_ISDIR(inode.mode):
@@ -482,12 +492,19 @@ def dump_fs(fs, target):
                     if not os.path.isdir(target_path):
                         os.makedirs(target_path)
                 elif stat.S_ISLNK(inode.mode):
+                    link_path = inode.data.decode('utf-8')
+                    if link_path:
+                        link_path = link_path[1:]
+                    link_target = os.path.realpath(os.path.join(target, link_path))
+                    if not is_safe_path(target, link_target):
+                        print(f"Path traversal attempt through symlink to {link_target}, discarding.")
+                        continue
                     print("writing S_ISLNK", path)
                     if not os.path.islink(target_path):
                         if os.path.exists(target_path):
                             print("file already exists as", inode.data)
                             continue
-                        os.symlink(inode.data, target_path)
+                        os.symlink(link_target, target_path)
                 elif stat.S_ISREG(inode.mode):
                     print("writing S_ISREG", path)
                     if not os.path.isfile(target_path):
@@ -561,7 +578,7 @@ def main():
         if not fs[JFFS2_NODETYPE_DIRENT]:
             continue
 
-        dest_path_fs = os.path.join(dest_path, "fs_%i" % fs_index)
+        dest_path_fs = os.path.realpath(os.path.join(dest_path, "fs_%i" % fs_index))
         print("dumping fs #%i to %s" % (fs_index, dest_path_fs))
         for key, value in fs.items():
             if key == "endianness":

--- a/src/scripts/jefferson
+++ b/src/scripts/jefferson
@@ -8,6 +8,8 @@ import zlib
 import binascii
 import cstruct
 import lzo
+import mmap
+import contextlib
 
 from jefferson import jffs2_lzma, rtime
 
@@ -165,7 +167,7 @@ class Jffs2_raw_dirent(cstruct.CStruct):
 
     def unpack(self, data, node_offset):
         cstruct.CStruct.unpack(self, data[: self.size])
-        self.name = data[self.size : self.size + self.nsize]
+        self.name = data[self.size : self.size + self.nsize].tobytes()
         self.node_offset = node_offset
 
         if mtd_crc(data[: self.size - 8]) == self.node_crc:
@@ -219,7 +221,7 @@ class Jffs2_raw_inode(cstruct.CStruct):
     def unpack(self, data):
         cstruct.CStruct.unpack(self, data[: self.size])
 
-        node_data = data[self.size : self.size + self.csize]
+        node_data = data[self.size : self.size + self.csize].tobytes()
         if self.compr == JFFS2_COMPR_NONE:
             self.data = node_data
         elif self.compr == JFFS2_COMPR_ZERO:
@@ -341,6 +343,8 @@ def scan_fs(content, endianness, verbose=False):
     jffs2_old_magic_bitmask_str = struct.pack(endianness + "H", JFFS2_OLD_MAGIC_BITMASK)
     jffs2_magic_bitmask_str = struct.pack(endianness + "H", JFFS2_MAGIC_BITMASK)
     fs_index = 0
+    content_mv = memoryview(content)
+
 
     fs = {}
     fs[fs_index] = {}
@@ -367,7 +371,7 @@ def scan_fs(content, endianness, verbose=False):
             pos = find_result_old
 
         unknown_node = Jffs2_unknown_node()
-        unknown_node.unpack(content[pos : pos + unknown_node.size])
+        unknown_node.unpack(content_mv[pos : pos + unknown_node.size])
         if not unknown_node.hdr_crc_match:
             pos += 1
             continue
@@ -381,7 +385,7 @@ def scan_fs(content, endianness, verbose=False):
             if unknown_node.nodetype in NODETYPES:
                 if unknown_node.nodetype == JFFS2_NODETYPE_DIRENT:
                     dirent = Jffs2_raw_dirent()
-                    dirent.unpack(content[0 + offset :], offset)
+                    dirent.unpack(content_mv[0 + offset :], offset)
                     if dirent.ino in dirent_dict:
                         print("duplicate inode use detected!!!")
                         fs_index += 1
@@ -401,25 +405,25 @@ def scan_fs(content, endianness, verbose=False):
                         print("0x%08X:" % (offset), dirent)
                 elif unknown_node.nodetype == JFFS2_NODETYPE_INODE:
                     inode = Jffs2_raw_inode()
-                    inode.unpack(content[0 + offset :])
+                    inode.unpack(content_mv[0 + offset :])
                     fs[fs_index][JFFS2_NODETYPE_INODE].append(inode)
                     if verbose:
                         print("0x%08X:" % (offset), inode)
                 elif unknown_node.nodetype == JFFS2_NODETYPE_XREF:
                     xref = Jffs2_raw_xref()
-                    xref.unpack(content[offset : offset + xref.size])
+                    xref.unpack(content_mv[offset : offset + xref.size])
                     fs[fs_index][JFFS2_NODETYPE_XREF].append(xref)
                     if verbose:
                         print("0x%08X:" % (offset), xref)
                 elif unknown_node.nodetype == JFFS2_NODETYPE_XATTR:
                     xattr = Jffs2_raw_xattr()
-                    xattr.unpack(content[offset : offset + xattr.size])
+                    xattr.unpack(content_mv[offset : offset + xattr.size])
                     fs[fs_index][JFFS2_NODETYPE_XREF].append(xattr)
                     if verbose:
                         print("0x%08X:" % (offset), xattr)
                 elif unknown_node.nodetype == JFFS2_NODETYPE_SUMMARY:
                     summary = Jffs2_raw_summary()
-                    summary.unpack(content[offset : offset + summary.size])
+                    summary.unpack(content_mv[offset : offset + summary.size])
                     summaries.append(summary)
                     fs[fs_index][JFFS2_NODETYPE_SUMMARY].append(summary)
                     if verbose:
@@ -430,6 +434,7 @@ def scan_fs(content, endianness, verbose=False):
                     pass
                 else:
                     print("Unhandled node type", unknown_node.nodetype, unknown_node)
+    content_mv.release()
     return fs.values()
 
 
@@ -557,42 +562,46 @@ def main():
     else:
         os.mkdir(dest_path)
 
-    with open(args.filesystem, "rb") as filesystem:
-        content = filesystem.read()
+    with contextlib.ExitStack() as context_stack:
+        filesystem = context_stack.enter_context(open(args.filesystem, "rb"))
+        filesystem_len = os.fstat(filesystem.fileno()).st_size
+        if 0 == filesystem_len:
+            return
+        content = context_stack.enter_context(
+            mmap.mmap(filesystem.fileno(), filesystem_len, access=mmap.ACCESS_READ)
+        )
+        magic = struct.unpack("<H", content[0:2])[0]
+        if magic in [JFFS2_OLD_MAGIC_BITMASK, JFFS2_MAGIC_BITMASK]:
+            endianness = cstruct.LITTLE_ENDIAN
+        else:
+            endianness = cstruct.BIG_ENDIAN
 
-    magic = struct.unpack("<H", content[0:2])[0]
-    if magic in [JFFS2_OLD_MAGIC_BITMASK, JFFS2_MAGIC_BITMASK]:
-        endianness = cstruct.LITTLE_ENDIAN
-    else:
-        endianness = cstruct.BIG_ENDIAN
+        set_endianness(endianness)
+        fs_list = list(scan_fs(content, endianness, verbose=args.verbose))
 
-    set_endianness(endianness)
-    fs_list = list(scan_fs(content, endianness, verbose=args.verbose))
-
-    fs_index = 1
-    for fs in fs_list:
-        if not fs[JFFS2_NODETYPE_DIRENT]:
-            continue
-
-        dest_path_fs = os.path.realpath(os.path.join(dest_path, "fs_%i" % fs_index))
-        print("dumping fs #%i to %s" % (fs_index, dest_path_fs))
-        for key, value in fs.items():
-            if key == "endianness":
-                if value == cstruct.BIG_ENDIAN:
-                    print("Endianness: Big")
-                elif value == cstruct.LITTLE_ENDIAN:
-                    print("Endianness: Little")
+        fs_index = 1
+        for fs in fs_list:
+            if not fs[JFFS2_NODETYPE_DIRENT]:
                 continue
 
-            print("%s count: %i" % (NODETYPES[key].__name__, len(value)))
+            dest_path_fs = os.path.realpath(os.path.join(dest_path, "fs_%i" % fs_index))
+            print("dumping fs #%i to %s" % (fs_index, dest_path_fs))
+            for key, value in fs.items():
+                if key == "endianness":
+                    if value == cstruct.BIG_ENDIAN:
+                        print("Endianness: Big")
+                    elif value == cstruct.LITTLE_ENDIAN:
+                        print("Endianness: Little")
+                    continue
 
-        if not os.path.exists(dest_path_fs):
-            os.mkdir(dest_path_fs)
+                print("%s count: %i" % (NODETYPES[key].__name__, len(value)))
 
-        dump_fs(fs, dest_path_fs)
-        print("-" * 10)
-        fs_index += 1
+            if not os.path.exists(dest_path_fs):
+                os.mkdir(dest_path_fs)
 
+            dump_fs(fs, dest_path_fs)
+            print("-" * 10)
+            fs_index += 1
 
 if __name__ == "__main__":
     main()

--- a/src/scripts/jefferson
+++ b/src/scripts/jefferson
@@ -4,6 +4,7 @@ import argparse
 import struct
 import stat
 import os
+import sys
 import zlib
 import binascii
 import cstruct
@@ -222,22 +223,26 @@ class Jffs2_raw_inode(cstruct.CStruct):
         cstruct.CStruct.unpack(self, data[: self.size])
 
         node_data = data[self.size : self.size + self.csize].tobytes()
-        if self.compr == JFFS2_COMPR_NONE:
-            self.data = node_data
-        elif self.compr == JFFS2_COMPR_ZERO:
+        try:
+            if self.compr == JFFS2_COMPR_NONE:
+                self.data = node_data
+            elif self.compr == JFFS2_COMPR_ZERO:
+                self.data = b"\x00" * self.dsize
+            elif self.compr == JFFS2_COMPR_ZLIB:
+                self.data = zlib.decompress(node_data)
+            elif self.compr == JFFS2_COMPR_RTIME:
+                self.data = rtime.decompress(node_data, self.dsize)
+            elif self.compr == JFFS2_COMPR_LZMA:
+                self.data = jffs2_lzma.decompress(node_data, self.dsize)
+            elif self.compr == JFFS2_COMPR_LZO:
+                self.data = lzo.decompress(node_data, False, self.dsize)
+            else:
+                print("compression not implemented", self)
+                print(node_data.hex()[:20])
+                self.data = node_data
+        except Exception as e:
+            print("Decompression error on inode {}: {}".format(self.ino, e), file=sys.stderr)
             self.data = b"\x00" * self.dsize
-        elif self.compr == JFFS2_COMPR_ZLIB:
-            self.data = zlib.decompress(node_data)
-        elif self.compr == JFFS2_COMPR_RTIME:
-            self.data = rtime.decompress(node_data, self.dsize)
-        elif self.compr == JFFS2_COMPR_LZMA:
-            self.data = jffs2_lzma.decompress(node_data, self.dsize)
-        elif self.compr == JFFS2_COMPR_LZO:
-            self.data = lzo.decompress(node_data, False, self.dsize)
-        else:
-            print("compression not implemented", self)
-            print(node_data.hex()[:20])
-            self.data = node_data
 
         if len(self.data) != self.dsize:
             print("data length mismatch!")
@@ -345,10 +350,8 @@ def scan_fs(content, endianness, verbose=False):
     fs_index = 0
     content_mv = memoryview(content)
 
-
     fs = {}
     fs[fs_index] = {}
-    fs[fs_index]["endianness"] = endianness
     fs[fs_index][JFFS2_NODETYPE_INODE] = []
     fs[fs_index][JFFS2_NODETYPE_DIRENT] = []
     fs[fs_index][JFFS2_NODETYPE_XATTR] = []
@@ -390,7 +393,6 @@ def scan_fs(content, endianness, verbose=False):
                         print("duplicate inode use detected!!!")
                         fs_index += 1
                         fs[fs_index] = {}
-                        fs[fs_index]["endianness"] = endianness
                         fs[fs_index][JFFS2_NODETYPE_INODE] = []
                         fs[fs_index][JFFS2_NODETYPE_DIRENT] = []
                         fs[fs_index][JFFS2_NODETYPE_XATTR] = []
@@ -577,23 +579,16 @@ def main():
             endianness = cstruct.BIG_ENDIAN
 
         set_endianness(endianness)
-        fs_list = list(scan_fs(content, endianness, verbose=args.verbose))
 
+        fs_list = list(scan_fs(content, endianness, verbose=args.verbose))
         fs_index = 1
         for fs in fs_list:
             if not fs[JFFS2_NODETYPE_DIRENT]:
                 continue
 
             dest_path_fs = os.path.realpath(os.path.join(dest_path, "fs_%i" % fs_index))
-            print("dumping fs #%i to %s" % (fs_index, dest_path_fs))
+            print("dumping fs #%i to %s (endianness: %s)" % (fs_index, dest_path_fs, endianness))
             for key, value in fs.items():
-                if key == "endianness":
-                    if value == cstruct.BIG_ENDIAN:
-                        print("Endianness: Big")
-                    elif value == cstruct.LITTLE_ENDIAN:
-                        print("Endianness: Little")
-                    continue
-
                 print("%s count: %i" % (NODETYPES[key].__name__, len(value)))
 
             if not os.path.exists(dest_path_fs):

--- a/src/scripts/jefferson
+++ b/src/scripts/jefferson
@@ -328,7 +328,6 @@ def set_endianness(endianness):
 
 
 def scan_fs(content, endianness, verbose=False):
-    set_endianness(endianness)
     summaries = []
     pos = 0
     jffs2_old_magic_bitmask_str = struct.pack(endianness + "H", JFFS2_OLD_MAGIC_BITMASK)
@@ -448,8 +447,6 @@ def get_device(inode):
 def dump_fs(fs, target):
     node_dict = {}
 
-    set_endianness(fs["endianness"])
-
     for dirent in fs[JFFS2_NODETYPE_DIRENT]:
         dirent.inodes = []
         for inode in fs[JFFS2_NODETYPE_INODE]:
@@ -550,8 +547,14 @@ def main():
     with open(args.filesystem, "rb") as filesystem:
         content = filesystem.read()
 
-    fs_list = list(scan_fs(content, cstruct.BIG_ENDIAN, verbose=args.verbose))
-    fs_list += list(scan_fs(content, cstruct.LITTLE_ENDIAN, verbose=args.verbose))
+    magic = struct.unpack("<H", content[0:2])[0]
+    if magic in [JFFS2_OLD_MAGIC_BITMASK, JFFS2_MAGIC_BITMASK]:
+        endianness = cstruct.LITTLE_ENDIAN
+    else:
+        endianness = cstruct.BIG_ENDIAN
+
+    set_endianness(endianness)
+    fs_list = list(scan_fs(content, endianness, verbose=args.verbose))
 
     fs_index = 1
     for fs in fs_list:

--- a/src/scripts/jefferson
+++ b/src/scripts/jefferson
@@ -492,19 +492,12 @@ def dump_fs(fs, target):
                     if not os.path.isdir(target_path):
                         os.makedirs(target_path)
                 elif stat.S_ISLNK(inode.mode):
-                    link_path = inode.data.decode('utf-8')
-                    if link_path:
-                        link_path = link_path[1:]
-                    link_target = os.path.realpath(os.path.join(target, link_path))
-                    if not is_safe_path(target, link_target):
-                        print(f"Path traversal attempt through symlink to {link_target}, discarding.")
-                        continue
                     print("writing S_ISLNK", path)
                     if not os.path.islink(target_path):
                         if os.path.exists(target_path):
                             print("file already exists as", inode.data)
                             continue
-                        os.symlink(link_target, target_path)
+                        os.symlink(inode.data, target_path)
                 elif stat.S_ISREG(inode.mode):
                     print("writing S_ISREG", path)
                     if not os.path.isfile(target_path):

--- a/src/scripts/jefferson
+++ b/src/scripts/jefferson
@@ -16,6 +16,7 @@ def PAD(x):
     return ((x) + 3) & ~3
 
 
+JFFS2_OLD_MAGIC_BITMASK = 0x1984
 JFFS2_MAGIC_BITMASK = 0x1985
 JFFS2_COMPR_NONE = 0x00
 JFFS2_COMPR_ZERO = 0x01
@@ -330,6 +331,7 @@ def scan_fs(content, endianness, verbose=False):
     set_endianness(endianness)
     summaries = []
     pos = 0
+    jffs2_old_magic_bitmask_str = struct.pack(endianness + "H", JFFS2_OLD_MAGIC_BITMASK)
     jffs2_magic_bitmask_str = struct.pack(endianness + "H", JFFS2_MAGIC_BITMASK)
     fs_index = 0
 
@@ -347,10 +349,15 @@ def scan_fs(content, endianness, verbose=False):
         find_result = content.find(
             jffs2_magic_bitmask_str, pos, len(content) - Jffs2_unknown_node.size
         )
-        if find_result == -1:
+        find_result_old = content.find(
+            jffs2_old_magic_bitmask_str, pos, len(content) - Jffs2_unknown_node.size
+        )
+        if find_result == -1 and find_result_old == -1:
             break
-        else:
+        if find_result != -1:
             pos = find_result
+        else:
+            pos = find_result_old
 
         unknown_node = Jffs2_unknown_node()
         unknown_node.unpack(content[pos : pos + unknown_node.size])
@@ -360,7 +367,10 @@ def scan_fs(content, endianness, verbose=False):
         offset = pos
         pos += PAD(unknown_node.totlen)
 
-        if unknown_node.magic == JFFS2_MAGIC_BITMASK:
+        if unknown_node.magic in [
+             JFFS2_MAGIC_BITMASK,
+             JFFS2_OLD_MAGIC_BITMASK,
+        ]:
             if unknown_node.nodetype in NODETYPES:
                 if unknown_node.nodetype == JFFS2_NODETYPE_DIRENT:
                     dirent = Jffs2_raw_dirent()

--- a/src/scripts/jefferson
+++ b/src/scripts/jefferson
@@ -7,6 +7,7 @@ import os
 import zlib
 import binascii
 import cstruct
+import lzo
 
 from jefferson import jffs2_lzma, rtime
 
@@ -229,6 +230,8 @@ class Jffs2_raw_inode(cstruct.CStruct):
             self.data = rtime.decompress(node_data, self.dsize)
         elif self.compr == JFFS2_COMPR_LZMA:
             self.data = jffs2_lzma.decompress(node_data, self.dsize)
+        elif self.compr == JFFS2_COMPR_LZO:
+            self.data = lzo.decompress(node_data, False, self.dsize)
         else:
             print("compression not implemented", self)
             print(node_data.hex()[:20])


### PR DESCRIPTION
We worked on our own fork on a few issues and battle tested our version of jefferson against a long list of JFFS2 firmwares. This PR is the product of our improvements.

It includes:
- automatic detection of endianness
- handling of decompression error on corrupted filesystems (fix #21 and #19)
- execution speedup by using memory mapped files (fix #27 , see #28)
- added support for legacy signature of JFFS2 (`0x1984`)
- added support for LZO compression (see #13)
- move cstruct to cstruct 2.1 (fix #33 , see #34 and #35) 
- a fix to protect against path traversals that would make jefferson write outside of the extraction directory