### PR TITLE
Fix path traversal bug.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod] 
+build/
+dist/
+jefferson.egg-info/

--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ sudo python3 setup.py install
 ### Usage
 
 ```bash
-$ jefferson filesystem.img -d outdir
+$ jefferson -f -d outdir filesystem.img
 ```

--- a/src/scripts/jefferson
+++ b/src/scripts/jefferson
@@ -54,12 +54,9 @@ JFFS2_NODETYPE_XREF = JFFS2_FEATURE_INCOMPAT | JFFS2_NODE_ACCURATE | 9
 def mtd_crc(data):
     return (binascii.crc32(data, -1) ^ -1) & 0xFFFFFFFF
 
-def is_safe_path(basedir, path, follow_symlinks=True):
-    if follow_symlinks:
-        matchpath = os.path.realpath(path)
-    else:
-        matchpath = os.path.abspath(path)
-    return basedir == os.path.commonpath((basedir, matchpath))
+def is_safe_path(basedir, real_path):
+    basedir = os.path.realpath(basedir)
+    return basedir == os.path.commonpath((basedir, real_path))
 
 cstruct.typedef("uint8", "uint8_t")
 cstruct.typedef("uint16", "jint16_t")
@@ -388,7 +385,7 @@ def dump_fs(fs, target):
         node_names.append(dirent.name.decode())
         path = "/".join(node_names)
 
-        target_path = os.path.realpath(os.path.join(os.getcwd(), target, path))
+        target_path = os.path.realpath(os.path.join(target, path))
 
         if not is_safe_path(target, target_path):
             print(f"Path traversal attempt to {target_path}, discarding.")


### PR DESCRIPTION
It will report path traversal with this command. Because is_safe_path doesn't get real path for 'basedir'.
```
jefferson -d ./111 ./test3.jffs2
```

